### PR TITLE
Added support for Jupyter.

### DIFF
--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -7,7 +7,7 @@
 # See LICENSE file for redistribution.
 
 import idaapi
-from ipyida import qtconsole, kernel
+from ipyida import ida_qtconsole, kernel
 
 class IPyIDAPlugIn(idaapi.plugin_t):
     wanted_name = "IPyIDA"
@@ -26,7 +26,7 @@ class IPyIDAPlugIn(idaapi.plugin_t):
         if not self.kernel.started:
             self.kernel.start()
         if self.widget is None:
-            self.widget = qtconsole.IPythonConsole(self.kernel.connection_file)
+            self.widget = ida_qtconsole.IPythonConsole(self.kernel.connection_file)
         self.widget.Show()
 
     def term(self):

--- a/ipyida/kernel.py
+++ b/ipyida/kernel.py
@@ -8,9 +8,9 @@
 # Author: Marc-Etienne M.Léveillé <leveille@eset.com>
 # See LICENSE file for redistribution.
 
-from IPython.kernel.zmq.kernelapp import IPKernelApp
+from ipykernel.kernelapp import IPKernelApp
 import IPython.utils.frame
-import IPython.kernel.zmq.iostream
+import ipykernel.iostream
 
 import sys
 import os
@@ -33,7 +33,7 @@ if sys.__stdout__.fileno() < 0:
 # in the console window. Used by wrap_excepthook.
 _ida_excepthook = sys.excepthook
 
-class IDATeeOutStream(IPython.kernel.zmq.iostream.OutStream):
+class IDATeeOutStream(ipykernel.iostream.OutStream):
 
     def write(self, string):
         "Write on both the previously saved IDA std output and zmq's stream"


### PR DESCRIPTION
Sadly, this comes on the expense of the older IPython, as the module names and hierarchy are different.

The change consists of 2 main parts.

The first is mostly changing imports and some class names, to match the new names and hierarchy found in Jupyter. It is important to note that any deprecated function needs to be replaced, as some of them no longer work (the old `IPython.lib.kernel.find_connection_file` function, as an example).

The second part is tricking Jupyter's import system. `qtconsole.qt_loaders.has_binding` (which is used to import Qt in Jupytrer) has this piece of code:

``` python
#importing top level PyQt4/PySide module is ok...
mod = __import__(module_name)
#...importing submodules is not
imp.find_module('QtCore', mod.__path__)
imp.find_module('QtGui', mod.__path__)
imp.find_module('QtSvg', mod.__path__)
```

With `module_name` being `PyQt5`, `PyQt4`, or `PySide`. So I had to monkey-patch the `find_module` function and make sure it succeeds on `QtSvg`. If someone finds a better way to do it, that would be great.

This closes #1, closes #2.
