### PR TITLE
Limit the qtconsole dependency to version < 4.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='ipyida',
       packages=['ipyida'],
       install_requires=[
           'ipykernel>=4.6, <5',
-          'qtconsole>=4.3'
+          'qtconsole>=4.3, <4.7'
       ],
       license="BSD",
       classifiers=[


### PR DESCRIPTION
qtconsole v4.7 has a [change](https://github.com/jupyter/qtconsole/commit/4a9c2a6086a76b20497f0ef636ef7ac71962e8aa) that breaks a monkey patch which ipyida is doing to it (this was already reported in #31). This pull request puts the workaround in the code to prevent users from accidentally installing a qtconsole version that breaks ipyida.