### PR TITLE
limited restart capability, not enough

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ image::ipyida-screenshot.png[IPyIDA screenshot,width=100%]
 == Install
 
 IPyIDA has been tested with IDA 6.6 and up on Windows, OS X and Linux, up to
-7.4.
+7.5.
 
 === Fast and easy install
 

--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -24,6 +24,34 @@ class IPyIDAPlugIn(idaapi.plugin_t):
         return idaapi.PLUGIN_KEEP
 
     def run(self, args):
+        # I'm not sure whether args were always wrapped in an object,
+        # so just incase, we will check for the case of `int`
+        if isinstance(args, int):
+            value = args
+        else:
+            value = getattr(args, 'value', 0)
+        
+        # trigger manual shutdown, ergo restart via:
+        #     ida_loader.load_and_run_plugin('ipyida', 2)
+        # then:
+        #     ida_loader.load_and_run_plugin('ipyida', 0)
+        #     (or press shift-. again)
+        if value == 2:
+            return self.term()
+
+        # enable diagnostics mode
+        if value == 3:
+            globals()['obj'] = self
+            print("""IPyIDA diagnostics instance created
+
+                instance be accessed via:
+                    import ipyida
+                    ipyida.ida_plugin.obj.*
+                e.g.  
+                    ipyida.ida_plugin.obj.term()
+            """)
+            return
+
         if not self.kernel.started:
             self.kernel.start()
         if self.widget is None:


### PR DESCRIPTION
Having managed to crash another IPython session, (this time due to ZMQ running out of file handles), it is becoming increasingly annoying not to be able to restart IPyIDA.

I made this small alterations in the hope of being able to do so, but alas this limited form of shutdown and restart doesn't even reload the color scheme.  Worse, output from `print` no longer appears in the IPython window after the plugin has been restarted (though it seems otherwise fine).

It is however a step in the right direction.