### PR TITLE
Wrap sys.displayhook and support notebook kernel 

### DIFF
--- a/.github/workflows/fetch_upstream.yml
+++ b/.github/workflows/fetch_upstream.yml
@@ -1,0 +1,37 @@
+name: Scheduled Merge Remote Action
+on: 
+  schedule:
+    - cron: '0 */6 * * *'
+    # scheduled for 00:00 every Monday
+  workflow_dispatch:
+
+jobs:
+  merge-upstream:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master             # set the branch to merge to
+          fetch-depth: 0
+      - name: Setup committer
+        run: |
+          git config --global user.email "misty@misty.moe"
+          git config --global user.name "NyaMisty"
+      - name: Merge Upstream
+        run: |
+          git remote add -f upstream "https://github.com/eset/ipyida" &&
+          git remote -v &&
+          git branch --all &&
+          git config --list &&
+          git checkout master &&
+          git rebase -v --fork-point upstream/master
+      #- name: Prepare to push  
+      #  run: git branch -f master
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          force: true
+      - uses: gautamkrishnar/keepalive-workflow@master # using the workflow with default settings

--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -6,13 +6,14 @@
 # Author: Marc-Etienne M.Léveillé <leveille@eset.com>
 # See LICENSE file for redistribution.
 
+import os
 import idaapi
 from ipyida import ida_qtconsole, kernel
 
 class IPyIDAPlugIn(idaapi.plugin_t):
     wanted_name = "IPyIDA"
     wanted_hotkey = "Shift-."
-    flags = 0
+    flags = idaapi.PLUGIN_FIX
     comment = ""
     help = "Starts an IPython qtconsole in IDA Pro"
     
@@ -21,6 +22,8 @@ class IPyIDAPlugIn(idaapi.plugin_t):
         self.kernel = _kernel
         self.widget = None
         monkey_patch_IDAPython_ExecScript()
+        if os.environ.get("JUPYTER_CONNECTION", None): # comes from jupyter
+            self.run(0)
         return idaapi.PLUGIN_KEEP
 
     def run(self, args):


### PR DESCRIPTION
1. Actually ida_ipython can receive jupyter notebook's connection file by JUPYTER_CONNECTION environment variable. In this way IDA can be spawned by Jupyter Notebook, and being like a normal IPython kernel.
![image](https://user-images.githubusercontent.com/5344431/128787454-2c4c3c63-d2ef-4ca6-9b8f-df51c23e64f9.png)

2. sys.displayhook are currently being used by IDAPython to display REPR's result, so we have to wrap it as well

3. Placing ipyida_plugin_stub.py under ipyida package is confusing, as the stub file will never able to import the ipyida package when being called directly from the source tree. So we can simply move it out, and everything will be working fine