### PR TITLE
fix: Prevent error when running with idat

### DIFF
--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -62,6 +62,9 @@ if idaapi.is_idaq():
 
     _kernel = kernel.IPythonKernel()
     _kernel.start()
+else:
+    # Required for the plugin init
+    _kernel = None
 
 def _do_load():
     ipyida_plugin_path = __file__

--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -55,11 +55,13 @@ def _setup_asyncio_event_loop():
         loop = qasync.QEventLoop(qapp, already_running=True)
         asyncio.set_event_loop(loop)
 
-if ida_qtconsole.is_using_pyqt5() and kernel.is_using_ipykernel_5():
-    _setup_asyncio_event_loop()
+# Only load the plugin when we have a GUI
+if idaapi.is_idaq():
+    if ida_qtconsole.is_using_pyqt5() and kernel.is_using_ipykernel_5():
+        _setup_asyncio_event_loop()
 
-_kernel = kernel.IPythonKernel()
-_kernel.start()
+    _kernel = kernel.IPythonKernel()
+    _kernel.start()
 
 def _do_load():
     ipyida_plugin_path = __file__


### PR DESCRIPTION
Hi,

When using `idat` with the plugin, it throws an exception.

```console
➜ $ idat64 -A /bin/ls
INFO:qasync:Forcing use of PyQt5 as Qt Implementation
INFO:qasync:Using Qt Implementation: PyQt5
DEBUG:asyncio:Using selector: EpollSelector
Exception ignored in: <function BaseEventLoop.__del__ at 0x7fa8df0b4940>
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/base_events.py", line 680, in __del__
    if not self.is_closed():
  File "/usr/lib/python3.9/asyncio/base_events.py", line 677, in is_closed
    return self._closed
AttributeError: 'QSelectorEventLoop' object has no attribute '_closed'
/home/alexis/.idapro/plugins/ipyida.py: No QApplication has been instantiated
Traceback (most recent call last):
  File "/opt/ida/ida-7.7-sp1/python/3/ida_idaapi.py", line 580, in IDAPython_ExecScript
    exec(code, g)
  File "/home/alexis/.idapro/plugins/ipyida.py", line 11, in <module>
    from ipyida.ida_plugin import PLUGIN_ENTRY, IPyIDAPlugIn
  File "/home/alexis/.local/lib/python3.9/site-packages/ipyida/ida_plugin.py", line 59, in <module>
    _setup_asyncio_event_loop()
  File "/home/alexis/.local/lib/python3.9/site-packages/ipyida/ida_plugin.py", line 55, in _setup_asyncio_event_loop
    loop = qasync.QEventLoop(qapp, already_running=True)
  File "/home/alexis/.local/lib/python3.9/site-packages/qasync/__init__.py", line 336, in __init__
    assert self.__app is not None, "No QApplication has been instantiated"
AssertionError: No QApplication has been instantiated
```

This small PR fixes it by just checking we're actually using the GUI (and QT) before loading the plugin.