### PR TITLE
make ipyida support global var defined in ida python script.

### DIFF
--- a/ipyida/kernel.py
+++ b/ipyida/kernel.py
@@ -117,7 +117,9 @@ class IPythonKernel(object):
                 # IDAPythonStdOut instance
                 log=logging.getLogger("ipyida_kernel")
             )
+            main_module = sys.modules['__main__']
             app.initialize()
+            app.kernel.user_module=main_module
 
             main = app.kernel.shell._orig_sys_modules_main_mod
             if main is not None:


### PR DESCRIPTION
It works, but why?

![image](https://github.com/eset/ipyida/assets/23459592/760a60de-3833-4fa3-899c-94d7ac2bd834)
