### PR TITLE
Removed usage of api unsupported in IDA 9

### DIFF
--- a/ipyida/ida_qtconsole.py
+++ b/ipyida/ida_qtconsole.py
@@ -107,9 +107,9 @@ class IdaRichJupyterWidget(RichJupyterWidget):
         try:
             addr = int(string, 16)
         except ValueError:
-            addr = idaapi.get_name_ea(idaapi.get_inf_structure().min_ea, string)
-        if addr >= idaapi.get_inf_structure().min_ea and \
-           addr <  idaapi.get_inf_structure().max_ea:
+            addr = idaapi.get_name_ea(idaapi.inf_get_min_ea(), string)
+        if addr >= idaapi.inf_get_min_ea() and \
+           addr <  idaapi.inf_get_max_ea():
             return lambda: idaapi.jumpto(addr)
         else:
             return None

--- a/ipyida/ida_qtconsole.py
+++ b/ipyida/ida_qtconsole.py
@@ -104,12 +104,12 @@ class IdaRichJupyterWidget(RichJupyterWidget):
 
     def _action_on_click(self, string):
         import re
+        min_ea, max_ea = ipyida.kernel.get_ea_bounds()
         try:
             addr = int(string, 16)
         except ValueError:
-            addr = idaapi.get_name_ea(idaapi.inf_get_min_ea(), string)
-        if addr >= idaapi.inf_get_min_ea() and \
-           addr <  idaapi.inf_get_max_ea():
+            addr = idaapi.get_name_ea(min_ea, string)
+        if addr >= min_ea and addr < max_ea:
             return lambda: idaapi.jumpto(addr)
         else:
             return None

--- a/ipyida/kernel.py
+++ b/ipyida/kernel.py
@@ -164,9 +164,10 @@ class IPythonKernel(object):
             printer.text(hex(obj))
         else:
             printer.text(str(obj))
-        info_struct = idaapi.get_inf_structure()
-        if obj >= info_struct.min_ea and obj < info_struct.max_ea:
-            addr = idaapi.prev_that(obj+1, info_struct.min_ea, idaapi.has_name)
+        min_ea = idaapi.inf_get_max_ea()
+        max_ea = idaapi.inf_get_max_ea()
+        if obj >= min_ea and obj < max_ea:
+            addr = idaapi.prev_that(obj+1, min_ea, idaapi.has_name)
             if addr != idaapi.BADADDR:
                 name = idaapi.get_name(addr)
                 demangled = idaapi.demangle_name(name, 0)

--- a/ipyida/kernel.py
+++ b/ipyida/kernel.py
@@ -47,6 +47,22 @@ def is_using_ipykernel_5():
     import ipykernel
     return hasattr(ipykernel.kernelbase.Kernel, "process_one")
 
+def get_ea_bounds():
+    """
+    Wraps getting the min and max ea to use either inf_get_min_ea
+    (IDA >= 7.?) or get_inf_structure (IDA < 7.?)
+
+    Returns: a tuple (min_ea, max_ea)
+    """
+    if hasattr(idaapi, "inf_get_min_ea"):
+        return (
+            idaapi.inf_get_min_ea(),
+            idaapi.inf_get_max_ea()
+        )
+    else:
+        inf = idaapi.get_inf_structure()
+        return ( inf.min_ea, inf.max_ea )
+
 
 class IDATeeOutStream(ipykernel.iostream.OutStream):
 
@@ -164,8 +180,7 @@ class IPythonKernel(object):
             printer.text(hex(obj))
         else:
             printer.text(str(obj))
-        min_ea = idaapi.inf_get_max_ea()
-        max_ea = idaapi.inf_get_max_ea()
+        min_ea, max_ea = get_ea_bounds()
         if obj >= min_ea and obj < max_ea:
             addr = idaapi.prev_that(obj+1, min_ea, idaapi.has_name)
             if addr != idaapi.BADADDR:


### PR DESCRIPTION
The `get_inf_structure` function is removed from IDA 9.
This pull request replaces the use of that API with a direct API that is compatible with both current versions of IDA and IDA 9.