### PR TITLE
Handle behavior change of get_event_loop in Python 3.14

### DIFF
--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -73,18 +73,20 @@ def _setup_asyncio_event_loop():
     import qasync
     import asyncio
 
-    def _link_qevent_loop():
+    try:
+        should_set_loop = not isinstance(asyncio.get_event_loop(), qasync.QEventLoop)
+    except RuntimeError:
+        # asyncio.get_event_loop() raises a RuntimeError if no loop is running
+        # This happends for Python >= 3.14
+        should_set_loop = True
+
+    if should_set_loop:
         qapp = _get_QApplication_instance()
         loop = qasync.QEventLoop(qapp, already_running=True)
         asyncio.set_event_loop(loop)
+    else:
+        print("Note: qasync event loop already set up.")
 
-    try:
-        if isinstance(asyncio.get_event_loop(), qasync.QEventLoop):
-            print("Note: qasync event loop already set up.")
-        else:
-            _link_qevent_loop()
-    except RuntimeError:
-        _link_qevent_loop()
 
 if (
     _get_QApplication_instance() is not None

--- a/ipyida/ida_plugin.py
+++ b/ipyida/ida_plugin.py
@@ -72,12 +72,19 @@ def PLUGIN_ENTRY():
 def _setup_asyncio_event_loop():
     import qasync
     import asyncio
-    if isinstance(asyncio.get_event_loop(), qasync.QEventLoop):
-        print("Note: qasync event loop already set up.")
-    else:
+
+    def _link_qevent_loop():
         qapp = _get_QApplication_instance()
         loop = qasync.QEventLoop(qapp, already_running=True)
         asyncio.set_event_loop(loop)
+
+    try:
+        if isinstance(asyncio.get_event_loop(), qasync.QEventLoop):
+            print("Note: qasync event loop already set up.")
+        else:
+            _link_qevent_loop()
+    except RuntimeError:
+        _link_qevent_loop()
 
 if (
     _get_QApplication_instance() is not None


### PR DESCRIPTION
Starting in Python 3.14, `asyncio.get_event_loop` raises a RuntimeError when there is no current event loop. This is a change from the previous behavior of returning a (new?) event loop with `running=False`.

This change handles the potential exception while maintaining compatibility with previous versions.